### PR TITLE
feat: Add real-time contribution graph to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 # 📊 GitHub Stats:
 ![](https://github-readme-stats.vercel.app/api?username=maulana-tech&theme=dark&hide_border=false&include_all_commits=true&count_private=true)<br/>
 ![](https://github-readme-streak-stats.herokuapp.com/?user=maulana-tech&theme=dark&hide_border=false)<br/>
+![](https://ghchart.rshah.org/maulana-tech?theme=dark)<br/>
 ![](https://github-readme-stats.vercel.app/api/top-langs/?username=maulana-tech&theme=dark&hide_border=false&include_all_commits=true&count_private=true&layout=compact)
 
 


### PR DESCRIPTION
Adds a GitHub contribution graph to the README.md to visually represent user contributions. This uses the ghchart.rshah.org service and is themed to match existing stats.